### PR TITLE
Fix deprecation notice

### DIFF
--- a/lib/atom-oss-license.coffee
+++ b/lib/atom-oss-license.coffee
@@ -304,7 +304,7 @@ module.exports = AtomOssLicense =
   # * `callback` A {Function} that manipulates the cursor position.
   restoreCursor: (editor, callback) ->
     marker = editor.markBufferPosition(
-      editor.getCursorBufferPosition(), persistent: false)
+      editor.getCursorBufferPosition())
     callback()
     editor.setCursorBufferPosition(marker.getHeadBufferPosition())
     marker.destroy()


### PR DESCRIPTION
Fix #2 

Hello @mmk2410 
As is Atom 1.25 the Deprecation Cop still throw this, here is a patch.

For reference:

https://github.com/ohanhi/atom-highlight-bad-chars/pull/13
https://github.com/ohanhi/atom-highlight-bad-chars/issues/7
https://github.com/smashwilson/merge-conflicts/pull/265