### PR TITLE
Make GPL licenses identical to the official

### DIFF
--- a/lib/license/gpl_v2.txt
+++ b/lib/license/gpl_v2.txt
@@ -1,16 +1,16 @@
 GNU GENERAL PUBLIC LICENSE
    Version 2, June 1991
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.

--- a/lib/license/gpl_v3.txt
+++ b/lib/license/gpl_v3.txt
@@ -12,4 +12,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Make GPL licenses identical to the official:
    - GPLv2: "," added before "USA"
    - GPLv3: change "http" to "https" 

Both changes are made base on the official GPL page:
https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
https://www.gnu.org/licenses/gpl-3.0.html